### PR TITLE
Clean up locking implementation in WeakEventHandlerBase

### DIFF
--- a/src/WeakEvent.Tests/WeakEventLockingTests.cs
+++ b/src/WeakEvent.Tests/WeakEventLockingTests.cs
@@ -1,0 +1,22 @@
+﻿using Xunit.Abstractions;
+
+namespace ByteAether.WeakEvent.Tests;
+public class WeakEventLockingTests(ITestOutputHelper output)
+{
+	private readonly ITestOutputHelper _output = output;
+
+	[Fact]
+	public async Task Handler_CanUnsubscribeItself()
+	{
+		WeakEvent e = new();
+		Action? handler = null;
+		handler = () =>
+		{
+			_output.WriteLine("Handler executing...");
+			e.Unsubscribe(handler!);
+		};
+
+		e.Subscribe(handler);
+		await e.PublishAsync();
+	}
+}


### PR DESCRIPTION
## Description
The `WeakEventHandlerBase` needs to protect *all* access to the `_handlers` list with the `_lock` to avoid state corruption.

Additionally, the handlers should be executed whilst the lock is *not* held, to avoid deadlocks if a handler attempts to call a method on the event object.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please specify):

## Checklist
- [x] The PR is submitted to the correct branch (`main`).
- [x] My code follows the project's coding style. (`.editorconfig`)
- [x] I have commented my code, particularly in hard-to-understand areas and public interfaces.
- [x] I have added or updated tests for the changes I made.
- [x] All new and existing tests passed.
- [x] I have updated the documentation where applicable.

## Testing Instructions
With the current code, a handler which attempts to modify the event object could result in corrupted state. At the very least, any attempt to modify the handlers list from a handler would result in an `InvalidOperationException`:

```
Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at WeakEventBase.PublishAsync(List`1 args, CancellationToken cancellationToken)
```

The simplistic solution is to wrap every access to the `_handlers` list in the lock. However, this would then result in a deadlock, since the handler is executed whilst the lock is already held, and the `SemaphoreSlim` does not support reentrancy.

Therefore, the actual solution is to also ensure that the handlers are invoked whilst the lock is not held. This involves taking a copy of the handlers list within the lock, and then operating on it outside of the lock.